### PR TITLE
Add AssetDeliveryProtocol.SmoothStreaming to WideVine/PlayReady policy

### DIFF
--- a/AzureMediaServicesConfigurationTool/Program.cs
+++ b/AzureMediaServicesConfigurationTool/Program.cs
@@ -165,13 +165,13 @@ namespace AzureMediaServicesConfigurationTool
                 deliveryPolicy = await context.AssetDeliveryPolicies.CreateAsync(
                     deliveryPolicyName,
                     AssetDeliveryPolicyType.DynamicCommonEncryption,
-                    AssetDeliveryProtocol.Dash,
+                    (AssetDeliveryProtocol.Dash | AssetDeliveryProtocol.SmoothStreaming),
                     deliveryPolicyConfiguration);
             }
             else
             {
                 deliveryPolicy.AssetDeliveryPolicyType = AssetDeliveryPolicyType.DynamicCommonEncryption;
-                deliveryPolicy.AssetDeliveryProtocol = AssetDeliveryProtocol.Dash;
+                deliveryPolicy.AssetDeliveryProtocol = (AssetDeliveryProtocol.Dash | AssetDeliveryProtocol.SmoothStreaming);
                 deliveryPolicy.AssetDeliveryConfiguration = deliveryPolicyConfiguration;
 
                 await deliveryPolicy.UpdateAsync();


### PR DESCRIPTION
This Pull-Request modifies the way the WideVine and PlayReady policies are created in order to enable SmoothStreaming on content protection. As it is required by Roku player which doesn't support DASH Format on manifest URL.